### PR TITLE
Add brfs transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ You specify your input files using the `files` option. You may specify more than
     // the reactify transform.
     react: true,
 
+    // When this option is true, you are able to use a small
+    // subset of node's fs module: readFileSync, readFile,
+    // readdirSync, and readdir.
+    // https://github.com/substack/brfs
+    brfs: true,
+
     // Pass additional options into browserify if
     // necessary. Overrides any module-level options.
     browserifyOptions: {

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ aposBrowserify.AposBrowserify = function(options, callback) {
   var development = options.development;
   var es2015 = options.es2015;
   var react = options.react;
+  var brfs = options.brfs
   var verbose = (options.verbose !== false);
   var notifications = options.notifications;
 
@@ -99,6 +100,10 @@ aposBrowserify.AposBrowserify = function(options, callback) {
     if(react){
       //if called for, compile JSX through reactify
       b.transform(reactify);
+    }
+
+    if(brfs){
+      b.transform('brfs');
     }
 
     // create the bundled file

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^6.4.0",
+    "brfs": "^1.4.1",
     "browserify": "6.3.x",
     "colors": "~1.0.3",
     "lodash": "~2.4.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "BSD",
   "dependencies": {
     "babel-preset-es2015": "^6.3.13",
-    "babelify": "^6.4.0",
+    "babelify": "^7.2.0",
     "brfs": "^1.4.1",
     "browserify": "6.3.x",
     "colors": "~1.0.3",


### PR DESCRIPTION
Adds the ability to use a small subset of node's fs module within
browserside js files. This can be useful for including non-js resources
such as templates in your bundled javascript.

For example:

``` js
var fs = require('fs');
var tpl = fs.readFileSync(__dirname + '/my_template.html');
var compiled = _.template(tpl);
// ...
```
